### PR TITLE
CI: fix deploy on github pages error

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: lts/*
 
       #👇 Add Storybook build and deploy to GitHub Pages as a step in the workflow
-      - uses: bitovi/github-actions-storybook-to-github-pages@v1.0.1
+      - uses: bitovi/github-actions-storybook-to-github-pages@v1.0.3
         with:
           install_command: yarn install # default: npm ci
           build_command: yarn build-storybook # default: npm run build-storybook

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -21,7 +21,7 @@ const config: StorybookConfig = {
     autodocs: "tag",
   },
   staticDirs: [
-    "..\\public",
+    "../public",
     {
       from: "../static/fonts",
       to: "static/fonts",


### PR DESCRIPTION
## Decription

Linux 환경에서는 path seperator로 '/'를 사용하기 때문에 path seperator로 '\\'를 사용하게 될 경우 에러가 발생하여, 수정했습니다.