### PR TITLE
Add more dependencies for playwright

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,45 +1,49 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
 {
-	"name": "Node.js",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
-	"remoteEnv": {
-		"API_URL": "http://ec2-43-200-72-31.ap-northeast-2.compute.amazonaws.com:9090",
-		"BASE_URL": "http://localhost:3000",
-		"IMAGE_SERVER_HOSTNAME": "unifest-dev-bucket.s3.ap-northeast-2.amazonaws.com",
-		"NEXT_PUBLIC_API_URL": "http://ec2-43-200-72-31.ap-northeast-2.compute.amazonaws.com:9090",
-		"NEXT_PUBLIC_BASE_URL": "http://localhost:3000",
-		"STORYBOOK_URL": "http://localhost:6006"
-	},
-	"customizations": {
-		"vscode": {
-			"extensions": [
-				"esbenp.prettier-vscode",
-				"dbaeumer.vscode-eslint",
-				"bradlc.vscode-tailwindcss",
-				"ms-vscode.live-server",
-				"formulahendry.auto-rename-tag",
-				"ms-vsliveshare.vsliveshare",
-				"streetsidesoftware.code-spell-checker",
-				"eamodio.gitlens",
-				"dsznajder.es7-react-js-snippets"
-			]
-		}
-	},
+  "name": "Node.js",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bookworm",
+  "remoteEnv": {
+    "API_URL": "http://ec2-43-200-72-31.ap-northeast-2.compute.amazonaws.com:9090",
+    "BASE_URL": "http://localhost:3000",
+    "IMAGE_SERVER_HOSTNAME": "unifest-dev-bucket.s3.ap-northeast-2.amazonaws.com",
+    "NEXT_PUBLIC_API_URL": "http://ec2-43-200-72-31.ap-northeast-2.compute.amazonaws.com:9090",
+    "NEXT_PUBLIC_BASE_URL": "http://localhost:3000",
+    "STORYBOOK_URL": "http://localhost:6006"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint",
+        "bradlc.vscode-tailwindcss",
+        "ms-vscode.live-server",
+        "formulahendry.auto-rename-tag",
+        "ms-vsliveshare.vsliveshare",
+        "streetsidesoftware.code-spell-checker",
+        "eamodio.gitlens",
+        "dsznajder.es7-react-js-snippets"
+      ]
+    }
+  },
 
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  // "features": {},
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "yarn install && npx playwright install"
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": [
+    "yarn install",
+    "npx playwright install-deps",
+    "npx playwright install"
+  ]
 
-	// Configure tool-specific properties.
-	// "customizations": {},
+  // Configure tool-specific properties.
+  // "customizations": {},
 
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
 }


### PR DESCRIPTION
## Summary

Add extra dependencies for playwright to run in remote development VM instance

## Description

An array of string is also accepted by `postCreateCommand` option, so I split the string into multiple commands for readability. And I added `npx playwright install-deps`, for playwright needs installed browser dependencies