### PR TITLE
Validate textfields while creating a booth

### DIFF
--- a/src/widgets/add-booth/ui/SetDescription.tsx
+++ b/src/widgets/add-booth/ui/SetDescription.tsx
@@ -7,7 +7,6 @@ import { useAutoAnimate } from "@formkit/auto-animate/react";
 import { useRouter } from "next/navigation";
 import { ChangeEvent } from "react";
 import { addBooth } from "../model/add-booth";
-import { useAuthStore } from "@/src/shared/model/provider/auth-store-provider";
 import useAuthFetch from "@/src/shared/model/auth/useAuthFetchList";
 
 export function SetDescription() {
@@ -30,7 +29,10 @@ export function SetDescription() {
   const handleDescriptionInputChange = (
     event: ChangeEvent<HTMLTextAreaElement>,
   ) => {
-    // TODO filter description input
+    if (event.target.value.length > 100) {
+      return;
+    }
+
     editDescription(event.target.value);
   };
 

--- a/src/widgets/add-booth/ui/SetDescription.tsx
+++ b/src/widgets/add-booth/ui/SetDescription.tsx
@@ -27,7 +27,7 @@ export function SetDescription() {
 
   const isFormValid = name && category && description;
 
-  const hanldeDescriptionInputChange = (
+  const handleDescriptionInputChange = (
     event: ChangeEvent<HTMLTextAreaElement>,
   ) => {
     // TODO filter description input
@@ -89,7 +89,7 @@ export function SetDescription() {
       </div>
       <Textarea
         value={description}
-        onChange={hanldeDescriptionInputChange}
+        onChange={handleDescriptionInputChange}
         placeholder="부스 컨텐츠, 판매 음식 등 자유롭게 부스를 소개해보세요."
         className="h-32 resize-none rounded-xl border border-[#D6D6D6] bg-[#FAFAFA] shadow-none placeholder:text-[#B0B0B0]"
       />

--- a/src/widgets/add-booth/ui/SetDescription.tsx
+++ b/src/widgets/add-booth/ui/SetDescription.tsx
@@ -94,7 +94,9 @@ export function SetDescription() {
         className="h-32 resize-none rounded-xl border border-[#D6D6D6] bg-[#FAFAFA] shadow-none placeholder:text-[#B0B0B0]"
       />
       <div className="mt-2 flex items-start justify-end">
-        <div className="text-[10px] font-medium text-gray">0/100자</div>
+        <div className="text-[10px] font-medium text-gray">
+          {(description && description.length) || 0}/100자
+        </div>
       </div>
       <div
         className="sticky bottom-0 mt-auto flex w-full gap-8 bg-white pb-4 pt-4"

--- a/src/widgets/add-booth/ui/SetName.tsx
+++ b/src/widgets/add-booth/ui/SetName.tsx
@@ -39,7 +39,7 @@ export function SetName() {
             onChange={handleNameInputChange}
           />
           <div className="flex items-start justify-end">
-            <div className="text-[10px] font-medium text-gray">{}/30자</div>
+            <div className="text-[10px] font-medium text-gray">{name.length}/30자</div>
           </div>
         </div>
       </div>

--- a/src/widgets/add-booth/ui/SetName.tsx
+++ b/src/widgets/add-booth/ui/SetName.tsx
@@ -2,21 +2,24 @@
 
 import { useBoothDraftStore } from "@/src/shared/model/provider/booth-draft-store-provider";
 import { Button } from "@/src/shared/ui/button";
-import DotIcon from "@/src/shared/ui/DotIcon";
-import RedDotIcon from "@/src/shared/ui/RedDotIcon";
 import { Input } from "@/src/shared/ui/input";
 import { useAutoAnimate } from "@formkit/auto-animate/react";
 import Link from "next/link";
-import React, { ChangeEvent, useState } from "react";
+import { ChangeEvent } from "react";
 
 export function SetName() {
-  const [nameInput, setNameInput] = useState("");
   const [parent] = useAutoAnimate();
-  const editName = useBoothDraftStore((state) => state.editName);
-  const name = useBoothDraftStore((state) => state.name);
+  const [name, editName] = useBoothDraftStore((state) => [
+    state.name,
+    state.editName,
+  ]);
 
-  const handleNameInputChange = (event: ChangeEvent<HTMLInputElement>) =>
+  const handleNameInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (name.length >= 30) {
+      return;
+    }
     editName(event.target.value);
+  };
 
   return (
     <>
@@ -36,7 +39,7 @@ export function SetName() {
             onChange={handleNameInputChange}
           />
           <div className="flex items-start justify-end">
-            <div className="text-[10px] font-medium text-gray">0/30자</div>
+            <div className="text-[10px] font-medium text-gray">{}/30자</div>
           </div>
         </div>
       </div>

--- a/src/widgets/add-booth/ui/SetName.tsx
+++ b/src/widgets/add-booth/ui/SetName.tsx
@@ -15,7 +15,8 @@ export function SetName() {
   ]);
 
   const handleNameInputChange = (event: ChangeEvent<HTMLInputElement>) => {
-    if (name.length >= 30) {
+    const updatedName = event.target.value;
+    if (updatedName.length > 30) {
       return;
     }
     editName(event.target.value);
@@ -39,7 +40,9 @@ export function SetName() {
             onChange={handleNameInputChange}
           />
           <div className="flex items-start justify-end">
-            <div className="text-[10px] font-medium text-gray">{name.length}/30자</div>
+            <div className="text-[10px] font-medium text-gray">
+              {name.length}/30자
+            </div>
           </div>
         </div>
       </div>

--- a/stories/SimpleSetBoothDescription.stories.tsx
+++ b/stories/SimpleSetBoothDescription.stories.tsx
@@ -32,7 +32,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const DescriptionEmpty: Story = {
+export const EmptyDescription: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(
@@ -55,7 +55,7 @@ export const DescriptionEmpty: Story = {
   },
 };
 
-export const DescriptionTyped: Story = {
+export const FilledDescription: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
@@ -74,7 +74,7 @@ export const DescriptionTyped: Story = {
   },
 };
 
-export const DescriptionOvertyping: Story = {
+export const OverfilledDescription: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 

--- a/stories/SimpleSetBoothDescription.stories.tsx
+++ b/stories/SimpleSetBoothDescription.stories.tsx
@@ -36,7 +36,7 @@ export const DescriptionTyped: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(
-      canvas.getByRole("link", { name: "건너뛰기" }),
+      canvas.getByRole("button", { name: "건너뛰기" }),
     ).toBeInTheDocument();
     await userEvent.type(
       canvas.getByPlaceholderText(
@@ -45,10 +45,10 @@ export const DescriptionTyped: Story = {
       "컴퓨터공학부 주점입니다. 새내기, 헌내기 모두 환영합니다.",
     );
     await expect(
-      canvas.getByRole("link", { name: "건너뛰기" }),
+      canvas.getByRole("button", { name: "건너뛰기" }),
     ).toBeInTheDocument();
     await expect(
-      await canvas.findByRole("link", { name: "입력완료" }),
+      await canvas.findByRole("button", { name: "입력완료" }),
     ).toBeInTheDocument();
   },
 };

--- a/stories/SimpleSetBoothDescription.stories.tsx
+++ b/stories/SimpleSetBoothDescription.stories.tsx
@@ -32,12 +32,33 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const DescriptionTyped: Story = {
+export const DescriptionEmpty: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(
       canvas.getByRole("button", { name: "건너뛰기" }),
     ).toBeInTheDocument();
+
+    await expect(
+      canvas.getByPlaceholderText(
+        /부스 컨텐츠, 판매 음식 등 자유롭게 부스를 소개해보세요/,
+      ),
+    ).toBeInTheDocument();
+
+    await expect(
+      canvas.getByRole("button", { name: "건너뛰기" }),
+    ).toBeInTheDocument();
+
+    await expect(
+      canvas.queryByRole("button", { name: "입력완료" }),
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const DescriptionTyped: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
     await userEvent.type(
       canvas.getByPlaceholderText(
         /부스 컨텐츠, 판매 음식 등 자유롭게 부스를 소개해보세요/,
@@ -50,5 +71,25 @@ export const DescriptionTyped: Story = {
     await expect(
       await canvas.findByRole("button", { name: "입력완료" }),
     ).toBeInTheDocument();
+  },
+};
+
+export const DescriptionOvertyping: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const descriptionTextField = canvas.getByPlaceholderText(
+      /부스 컨텐츠, 판매 음식 등 자유롭게 부스를 소개해보세요/,
+    );
+
+    await userEvent.type(
+      canvas.getByPlaceholderText(
+        /부스 컨텐츠, 판매 음식 등 자유롭게 부스를 소개해보세요/,
+      ),
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+    );
+    await expect(descriptionTextField.textContent?.length).toBeLessThanOrEqual(
+      100,
+    );
   },
 };

--- a/stories/SimpleSetBoothName.stories.tsx
+++ b/stories/SimpleSetBoothName.stories.tsx
@@ -39,7 +39,7 @@ export const FilledInput: Story = {
       "컴퓨터공학부 주점",
     );
     await expect(
-      canvas.findByRole("link", { name: /입력완료/ }),
+      canvas.getByRole("link", { name: /입력완료/ }),
     ).toBeInTheDocument();
   },
 };

--- a/stories/SimpleSetBoothName.stories.tsx
+++ b/stories/SimpleSetBoothName.stories.tsx
@@ -30,7 +30,19 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const FilledInput: Story = {
+export const EmptyName: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByRole("textbox", { name: "" })).toBeInTheDocument();
+
+    await expect(
+      canvas.queryByRole("link", { name: /입력완료/ }),
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const FilledName: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
@@ -41,5 +53,20 @@ export const FilledInput: Story = {
     await expect(
       canvas.getByRole("link", { name: /입력완료/ }),
     ).toBeInTheDocument();
+  },
+};
+
+export const OverfilledName: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const nameTextField = canvas.getByPlaceholderText(/부스 이름/);
+
+    await userEvent.type(
+      nameTextField,
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+    );
+
+    await expect(nameTextField.textContent?.length).toBeLessThanOrEqual(30);
   },
 };


### PR DESCRIPTION
## Summary

booth name, booth description의 길이 관련 validation을 추가하였습니다.

## Description

- booth name은 30자 이내로, booth description은 100자 이내로만 입력 가능하도록 수정하였습니다.
- Booth name, booth description에 대하여 초기 empty string일 때의 test를 추가하였습니다.
- Storybook interaction testing을 통하여 interaction 시각화를 하고 통과하는 것을 로컬 머신에서 확인하였습니다.
- Storybook interaction testing stories 이름을 직관적으로 바꾸었습니다. (noun + adjective => adjective + noun, overtyped => overfilled)