### PR TITLE
fix: exclude id while making update request

### DIFF
--- a/src/features/booth/api/booth.ts
+++ b/src/features/booth/api/booth.ts
@@ -22,14 +22,14 @@ export const editBooth = async (
   accessToken: string,
   booth: Omit<Booth, "enabled" | "menus" | "detail" | "description">,
 ) => {
-  const { id } = booth;
+  const { id, ...boothWithoutId } = booth;
   const response = await fetch(`${API_URL}/api/booths/${id}`, {
     method: HTTPMethod.PATCH,
     headers: {
       [`${HTTPHeaderKey.CONTENT_TYPE}`]: HTTPHeaderValue.APPLICATION_JSON,
       [`${HTTPHeaderKey.AUTHORIZATION}`]: getAuthorziationValue(accessToken),
     },
-    body: JSON.stringify(booth),
+    body: JSON.stringify(boothWithoutId),
   });
   const data = await response.json();
   return data;


### PR DESCRIPTION
## Description

부스 편집을 api 요청을 할 때 boothId를 request body에서 제외하였습니다.