### PR TITLE
Feat/menu API 연결.

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-storybook": "^0.8.0",
     "gh-pages": "^6.1.1",
-    "husky": "^9.1.6",
+    "husky": "^9.0.11",
     "lint-staged": "^15.2.2",
     "msw": "^2.2.14",
     "msw-storybook-addon": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-storybook": "^0.8.0",
     "gh-pages": "^6.1.1",
-    "husky": "^9.0.11",
+    "husky": "^9.1.6",
     "lint-staged": "^15.2.2",
     "msw": "^2.2.14",
     "msw-storybook-addon": "^2.0.3",

--- a/src/features/booth/api/addBooth.ts
+++ b/src/features/booth/api/addBooth.ts
@@ -1,10 +1,52 @@
-import { API_URL, HTTPMethod } from "@/src/shared/api/config";
-import { Booth } from "@/src/shared/lib/types";
+import {
+  API_URL,
+  getAuthorziationValue,
+  HTTPHeaderKey,
+  HTTPHeaderValue,
+  HTTPMethod,
+} from "@/src/shared/api/config";
+import { Booth, BoothCategoryKeys } from "@/src/shared/lib/types";
+import { MenuItemState } from "@/src/shared/model/store/booth-edit-store";
 
+const FESTIVAL_ID = 1;
+interface ProductForCreate {
+  menuStatus?: MenuItemState | null;
+  id?: number;
+  name: string;
+  price: number;
+  imgUrl?: string;
+}
+interface BoothForCreate {
+  id?: number;
+  name: string;
+  category: BoothCategoryKeys;
+  description?: string;
+  detail?: string;
+  thumbnail: string;
+  warning?: string;
+  location: string;
+  latitude: number;
+  longitude: number;
+  menus: ProductForCreate[];
+  enabled?: boolean;
+  festivalId: number;
+}
 // TODO add body
-export const addBooth = async (booth: Booth) => {
+export const addBooth = async (accessToken: string, booth: Booth) => {
+  const { id, ...boothWithoutId } = booth as BoothForCreate;
+  boothWithoutId.menus.forEach((item) => {
+    delete item.menuStatus;
+    delete item.id;
+  });
+  //너무 쌉 하드코딩임..
+  boothWithoutId.festivalId = FESTIVAL_ID;
   const response = await fetch(`${API_URL}/api/booths`, {
     method: HTTPMethod.POST,
+    headers: {
+      [`${HTTPHeaderKey.CONTENT_TYPE}`]: HTTPHeaderValue.APPLICATION_JSON,
+      [`${HTTPHeaderKey.AUTHORIZATION}`]: getAuthorziationValue(accessToken),
+    },
+    body: JSON.stringify(boothWithoutId),
   });
   const data = await response.json();
   return data;

--- a/src/features/menu/model/menu.ts
+++ b/src/features/menu/model/menu.ts
@@ -6,18 +6,31 @@ import {
   getAuthorziationValue,
 } from "@/src/shared/api/config";
 
+import { Product } from "@/src/shared/lib/types";
+
+interface ProductForFetch {
+  name: string;
+  price: number;
+  imgUrl?: string;
+}
+
 export const uploadMenuItem = async (
   accessToken: string,
   boothId: number,
-  menuItem: { name: string; price: number; imgUrl: string },
+  menuItem: ProductForFetch,
 ) => {
+  const _menu: ProductForFetch = {
+    name: menuItem.name,
+    price: menuItem.price,
+    imgUrl: menuItem.imgUrl,
+  };
   const response = await fetch(`${API_URL}/api/menus/${boothId}`, {
     method: HTTPMethod.POST,
     headers: {
       [`${HTTPHeaderKey.CONTENT_TYPE}`]: HTTPHeaderValue.APPLICATION_JSON,
       [`${HTTPHeaderKey.AUTHORIZATION}`]: getAuthorziationValue(accessToken),
     },
-    body: JSON.stringify(menuItem),
+    body: JSON.stringify(_menu),
   });
   const data = await response.json();
   return data;
@@ -30,6 +43,28 @@ export const deleteMenuItem = async (accessToken: string, menuId: number) => {
       [`${HTTPHeaderKey.AUTHORIZATION}`]: getAuthorziationValue(accessToken),
     },
   });
+  const data = await response.json();
+  return data;
+};
+
+export const editMenu = async (accessToken: string, menuItem: Product) => {
+  const _menu: ProductForFetch = {
+    name: menuItem.name,
+    price: menuItem.price,
+    imgUrl: menuItem.imgUrl,
+  };
+
+  const response = await fetch(`${API_URL}/api/menus/${menuItem.id}`, {
+    method: HTTPMethod.PATCH,
+    headers: {
+      [`${HTTPHeaderKey.CONTENT_TYPE}`]: HTTPHeaderValue.APPLICATION_JSON,
+      [`${HTTPHeaderKey.AUTHORIZATION}`]: getAuthorziationValue(accessToken),
+    },
+    body: JSON.stringify(_menu),
+  });
+  // return response;
+
+  //얘는 왜 return을 menuID를 하지...??
   const data = await response.json();
   return data;
 };

--- a/src/features/menu/ui/MenuItem.tsx
+++ b/src/features/menu/ui/MenuItem.tsx
@@ -27,7 +27,7 @@ interface MenuItemPropsType {
   name: string;
   price: number;
   imgUrl?: string;
-  menuStatus: MenuItemState | null;
+  menuStatus: MenuItemState | null | undefined;
   edit: (id: number, menuProp: Partial<Product>) => void;
   add: () => void;
   remove: (id: number) => void;

--- a/src/widgets/booth/ui/Add.tsx
+++ b/src/widgets/booth/ui/Add.tsx
@@ -42,6 +42,7 @@ import { useRouter } from "next/navigation";
 import { MenuItemState } from "@/src/shared/model/store/booth-edit-store";
 import { deleteMenuItem } from "@/src/features/menu/model/menu";
 import { useBoothDetailsDraftStore } from "@/src/shared/model/provider/booth-details-draft-store-provider";
+import { addBooth } from "@/src/features/booth/api/addBooth";
 
 interface MenuItem {
   id: number;
@@ -87,7 +88,7 @@ export function Add({ boothId }: { boothId: number }) {
   const [menuItemParent] = useAutoAnimate();
   useRequireAuth(AuthType.MEMBER);
 
-  const editAuthBooth = useAuthFetch(editBooth);
+  const addAuthBooth = useAuthFetch(addBooth);
   const form = useForm<z.infer<typeof boothEditSchema>>({
     resolver: zodResolver(boothEditSchema),
     defaultValues: {
@@ -106,7 +107,7 @@ export function Add({ boothId }: { boothId: number }) {
   const router = useRouter();
 
   const onSubmit = async (data: any) => {
-    await editAuthBooth({ id: boothId, thumbnail, ...data });
+    await addAuthBooth({ id: boothId, thumbnail, ...data, menus: menuList });
     router.push("/");
   };
 

--- a/src/widgets/booth/ui/Edit.tsx
+++ b/src/widgets/booth/ui/Edit.tsx
@@ -40,7 +40,11 @@ import useAuthFetch from "@/src/shared/model/auth/useAuthFetchList";
 import { editBooth } from "@/src/features/booth/api/booth";
 import { useRouter } from "next/navigation";
 import { MenuItemState } from "@/src/shared/model/store/booth-edit-store";
-import { deleteMenuItem } from "@/src/features/menu/model/menu";
+import {
+  uploadMenuItem,
+  deleteMenuItem,
+  editMenu,
+} from "@/src/features/menu/model/menu";
 
 interface MenuItem {
   id: number;
@@ -89,6 +93,9 @@ export function Edit({ boothId }: { boothId: number }) {
   useRequireAuth(AuthType.MEMBER);
 
   const editAuthBooth = useAuthFetch(editBooth);
+  const addAuthMenu = useAuthFetch(uploadMenuItem);
+  const editAuthMenu = useAuthFetch(editMenu);
+  const deleteAuthMenu = useAuthFetch(deleteMenuItem);
 
   const form = useForm<z.infer<typeof boothEditSchema>>({
     resolver: zodResolver(boothEditSchema),
@@ -111,6 +118,14 @@ export function Edit({ boothId }: { boothId: number }) {
 
   const onSubmit = async (data: any) => {
     await editAuthBooth({ id: boothId, thumbnail, enabled, ...data });
+    menuList.forEach(async (menuItem) => {
+      const res = await editAuthMenu(menuItem);
+      //이거 res가 왜 responseBody 처럼 오지 않는 걸까요
+      //TODO : 현재 로직은 이론상 메뉴의 수가 매우 많아지면 오작동함!!!!!! 이번 축제 때는 그러지 않겠지...만...?
+      if (res === null) {
+        await addAuthMenu(boothId, menuItem);
+      }
+    });
     router.push("/");
   };
 


### PR DESCRIPTION
## 진행사항
- 메뉴의 생성
- 메뉴의 수정(업데이트)

## 문제사항
- Edit.tsx 122번째 줄의 ```const res = await editAuthMenu(menuItem);```가 결과값이 왜 responseBody처럼 안 오고 menuID가 오는 지 모르겠음
- 현재 로직 상, 총 메뉴의 갯수가 억 단위에 들어가면 충돌이 일어나 망함.  나중에 개선 필요

## 실행 결과
### 메뉴의 생성
![chrome-capture-2024-9-21](https://github.com/user-attachments/assets/f733de2f-811c-451e-b828-c42f626e7470)
#### 저글링이라는 메뉴를 50원에 생성하는 모습
---
### 메뉴의 수정
![chrome-capture-2024-9-21 (2)](https://github.com/user-attachments/assets/b7c88073-6db5-4af5-ad61-e2dc9fc303d7)
#### 저글링이라는 메뉴의 가격을 올리는 모습
---
### 메뉴의 삭제 (원래 동작이 잘 동작한다는 점)
![chrome-capture-2024-9-21 (1)](https://github.com/user-attachments/assets/1833df48-84dc-48ab-8fdc-344efd6faade)
#### 저글링과 마린이라는 메뉴를 삭제하는 모습