### PR TITLE
infra: use different gaId

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -42,7 +42,7 @@ export default function RootLayout({
           </AuthStoreProvider>
         </MSWProvider>
       </body>
-      <GoogleAnalytics gaId="G-R77K56TYEY" />
+      <GoogleAnalytics gaId="G-7WTXSFSS6M" />
     </html>
   );
 }


### PR DESCRIPTION
##

## Description

GA failed to seperate admin data from user data since we use the same account as the mobile one. By using another account, we can analyze it differently