### PR TITLE
서버 도메인 이전에 따라 public api url을 이전

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,7 +6,7 @@ pages_build_output_dir = ".vercel/output/static"
 # Preview 환경 설정 (non-production branches)
 [env.preview.vars]
 IMAGE_SERVER_HOSTNAME = "unifest-prod-bucket.s3.ap-northeast-2.amazonaws.com"
-NEXT_PUBLIC_API_URL = "https://unifest.store"
+NEXT_PUBLIC_API_URL = "https://unifest.shop"
 STORYBOOK_URL = "http://localhost:6006"
 PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS = "1"
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY = "AIzaSyDoGN7QvGfdISEXjZ_Q9QItThvnd0WxPlA"
@@ -16,9 +16,9 @@ BASE_URL = "$CF_PAGES_URL"
 # Production 환경 설정 (main branch)
 [env.production.vars]
 IMAGE_SERVER_HOSTNAME = "unifest-prod-bucket.s3.ap-northeast-2.amazonaws.com"
-NEXT_PUBLIC_API_URL = "https://unifest.store"
+NEXT_PUBLIC_API_URL = "https://unifest.shop"
 STORYBOOK_URL = "http://localhost:6006"
 PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS = "1"
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY = "AIzaSyDoGN7QvGfdISEXjZ_Q9QItThvnd0WxPlA"
-NEXT_PUBLIC_GOOGLE_MAPS_ID = "121606c3fffdba11"
 BASE_URL = "https://unifest.pages.dev"
+NEXT_PUBLIC_GOOGLE_MAPS_ID = "121606c3fffdba11"


### PR DESCRIPTION
## Summary

Cloudflare Pages 환경 변수 `NEXT_PUBLIC_API_URL`을 기존 `https://unifest.store`에서 `https://unifest.shop`으로 변경했습니다. Preview와 Production 환경 모두에 적용되며, 서비스 도메인 변경에 따른 API 연동 주소 일원화 목적입니다.

## PR 유형 및 세부 작업 내용

- [x] 빌드 부분 혹은 패키지 매니저 수정

- 세부 내용:
  - `wrangler.toml`의 `[env.preview.vars]`와 `[env.production.vars]` 내 `NEXT_PUBLIC_API_URL` 값을 `https://unifest.shop`으로 변경
  - 기타 환경 변수 및 코드에는 영향 없음

## test 완료 여부 (선택)
- 로컬 및 배포 환경에서 환경 변수 값이 정상 반영되는지 확인 필요

## 리뷰 요구사항 (선택)
- 추가 확인이 필요한 부분이나, 영향 범위에 대한 의견이 있다면 코멘트 부탁드립니다.