### PR TITLE
확성기 아이콘 숨김

### DIFF
--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -99,7 +99,7 @@ export function Header() {
         {pathname.includes(BoothDetailPathSegment.booths) && (
           <Link
             href={`/megaphone/${getBoothId(pathname)}`}
-            className="absolute right-4"
+            className="absolute right-4 hidden"
           >
             <SpeakerIcon />
           </Link>


### PR DESCRIPTION
UI에서 메가폰 아이콘을 숨기는 기능을 추가했습니다. 상명대 축제에서는 확성기를 사용할 계획이 없으므로, 버튼을 화면 상에서 숨겼습니다.

- 메가폰 아이콘이 더 이상 화면에 표시되지 않도록 관련 컴포넌트/스타일 수정
- 기타 UI에는 영향 없음

로컬 환경에서 메가폰 아이콘이 정상적으로 숨겨지는지 확인함

UI/UX 관점에서 추가 의견이 있다면 코멘트 부탁드립니다.