### PR TITLE
fix : 하나의 플로우에서 메뉴 생성 후 삭제할 경우 에러 발생

### DIFF
--- a/src/features/auth/model/auth.ts
+++ b/src/features/auth/model/auth.ts
@@ -38,8 +38,8 @@ export const signUp = async (
       // case University.SangMyung:
       //   return 5;
       case University.Gacheon:
-        const api_url = `${API_URL}`
-        if(api_url.includes('unifest')){
+        
+        if(process.env.NODE_ENV === 'production' ){
           return 15;
         }else{
           return 1;

--- a/src/features/auth/model/auth.ts
+++ b/src/features/auth/model/auth.ts
@@ -29,19 +29,27 @@ export const signUp = async (
   };
   const id = () => {
     switch (authDetails.university) {
-      case University.Konkuk:
-        return 1;
-      case University.Transportation:
-        return 3;
-      case University.Korea:
-        return 4;
-      case University.SangMyung:
-        return 5;
+      // case University.Konkuk:
+      //   return 1;
+        // case University.Transportation:
+      //   return 3;
+      // case University.Korea:
+      //   return 4;
+      // case University.SangMyung:
+      //   return 5;
+      case University.Gacheon:
+        const api_url = `${API_URL}`
+        if(api_url.includes('unifest')){
+          return 15;
+        }else{
+          return 1;
+        }
+
+
       default:
         throw new Error("올바르지 않은 요청입니다");
     }
   };
-  console.log(id());
   return publicClient
     .post("members", {
       json: { ...body, schoolId: id() }, // TODO change schoolId based on university

--- a/src/features/menu/ui/MenuItem.tsx
+++ b/src/features/menu/ui/MenuItem.tsx
@@ -14,7 +14,7 @@ import { RadioGroupItem } from "@/src/shared/ui/radio-group";
 import { MenuStatus } from "../lib/types";
 import { uploadImage } from "@/src/shared/api/image";
 import { useDeleteMenuItem } from "../api";
-
+//TODO : isOrigin boolean이 아닌 다른 방식으로 개선하기
 interface MenuItemPropsType {
   boothId: number;
   id: number;

--- a/src/features/menu/ui/MenuItem.tsx
+++ b/src/features/menu/ui/MenuItem.tsx
@@ -1,7 +1,7 @@
 import { CardContent } from "@/src/shared/ui/card";
 import { Input } from "@/src/shared/ui/input";
 
-import { ChangeEvent } from "react";
+import { ChangeEvent, useEffect } from "react";
 
 import { Label } from "@/src/shared/ui/label";
 import { PlusCircledIcon } from "@radix-ui/react-icons";
@@ -24,6 +24,7 @@ interface MenuItemPropsType {
   menuStatus: MenuStatus;
   edit: (id: number, menuProp: Partial<Product>) => void;
   remove: (id: number) => void;
+  isOrigin: boolean;
 }
 
 export function MenuCard({
@@ -35,7 +36,9 @@ export function MenuCard({
   menuStatus,
   remove,
   edit,
+  isOrigin,
 }: MenuItemPropsType) {
+  //이번 플로우에서 생성한 메뉴 ID모음
   const handleChangeImage = async (event: ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files![0];
     if (!file) {
@@ -84,7 +87,7 @@ export function MenuCard({
           <Button
             type="button"
             onClick={async () => {
-              if (menuItemId) {
+              if (menuItemId && isOrigin) {
                 await deleteMenuItem(menuItemId);
               }
               remove(menuItemId);

--- a/src/widgets/booth/ui/Add.tsx
+++ b/src/widgets/booth/ui/Add.tsx
@@ -110,11 +110,7 @@ export function Add({ boothId }: { boothId: number }) {
   const { mutateAsync: createMenuItem } = useCreateMenuItem(boothId);
   const { mutateAsync: patchBoothSchedule } = usePatchBoothSchedule(boothId);
 
-  const [originMenus, setOriginMenus] = useState<number[]>();
-
-  useEffect(() => {
-    setOriginMenus(menuList.map((value) => value.id));
-  }, []);
+  const originMenus:number[] = menuList.map((value) => value.id);
 
   // const { mutateAsync: createBooth } = useCreateBooth({
   //   onCreate: () => {

--- a/src/widgets/booth/ui/Add.tsx
+++ b/src/widgets/booth/ui/Add.tsx
@@ -30,7 +30,7 @@ import {
   usePatchBoothSchedule,
   useUpdateBooth,
 } from "@/src/features/booth/api";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useFestivalListQuery } from "@/src/features/festival/api";
 import { useGetMyProfile } from "@/src/entities/members/api";
 import { useCreateMenuItem, useUpdateMenuItem } from "@/src/features/menu/api";
@@ -109,6 +109,12 @@ export function Add({ boothId }: { boothId: number }) {
   const { mutateAsync: updateBooth } = useUpdateBooth(boothId);
   const { mutateAsync: createMenuItem } = useCreateMenuItem(boothId);
   const { mutateAsync: patchBoothSchedule } = usePatchBoothSchedule(boothId);
+
+  const [originMenus, setOriginMenus] = useState<number[]>();
+
+  useEffect(() => {
+    setOriginMenus(menuList.map((value) => value.id));
+  }, []);
 
   // const { mutateAsync: createBooth } = useCreateBooth({
   //   onCreate: () => {
@@ -378,6 +384,7 @@ export function Add({ boothId }: { boothId: number }) {
                 menuStatus={menuItem.menuStatus}
                 remove={removeMemuItem}
                 edit={editMenuItem}
+                isOrigin={originMenus?.includes(menuItem.id) ?? false}
               />
             ))}
             <CardFooter>

--- a/src/widgets/booth/ui/Edit.tsx
+++ b/src/widgets/booth/ui/Edit.tsx
@@ -131,7 +131,10 @@ export function Edit({ boothId }: { boothId: number }) {
   const queryClient = useQueryClient();
 
   const { data: myProfile } = useGetMyProfile();
-
+  const [originMenus, setOriginMenus] = useState<number[]>();
+  useEffect(() => {
+    setOriginMenus(menuList.map((value) => value.id));
+  }, []);
   const onSubmit = async (data: any) => {
     setIsSubmitting(true);
     const booth = myProfile.booths.find((booth) => booth.id === boothId)!;
@@ -413,6 +416,7 @@ export function Edit({ boothId }: { boothId: number }) {
                 boothId={boothId}
                 remove={removeMemuItem}
                 edit={editMenuItem}
+                isOrigin={originMenus?.includes(menuItem.id) ?? false}
                 {...menuItem}
               />
             ))}

--- a/src/widgets/sign-up/lib/sign-up-schema.ts
+++ b/src/widgets/sign-up/lib/sign-up-schema.ts
@@ -6,6 +6,7 @@ export enum University {
   Transportation = "한국교통대학교",
   Korea = "고려대학교",
   SangMyung = "상명대학교",
+  Gacheon = "가천대학교"
 }
 
 export const signUpSchema = z

--- a/src/widgets/sign-up/ui/SignUp.tsx
+++ b/src/widgets/sign-up/ui/SignUp.tsx
@@ -73,7 +73,10 @@ export function SignUp() {
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    <SelectItem value={University.Korea}>
+                  <SelectItem value={University.Gacheon}>
+                      {University.Gacheon}
+                    </SelectItem>
+                    {/* <SelectItem value={University.Korea}>
                       {University.Korea}
                     </SelectItem>
                     <SelectItem value={University.SangMyung}>
@@ -84,7 +87,7 @@ export function SignUp() {
                     </SelectItem>
                     <SelectItem value={University.Konkuk}>
                       {University.Konkuk}
-                    </SelectItem>
+                    </SelectItem> */}
                   </SelectContent>
                 </Select>
                 <FormMessage />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,11 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", 
+  "**/*.stories.ts",
+  "**/*.stories.tsx",
+  "**/*.stories.jsx",
+  "**/*.stories.mdx",
+  ".storybook",
+  "storybook-static"]
 }


### PR DESCRIPTION
### 개요
이전에 간혹 보이던 버그였는데 Assistant PM 이지유님이 확실한 원인을 찾아주셨습니다.

> 운영자모드 -> 부스 새로 생성하기 -> 간단하게 생성하기 -> 문제x
운영자모드 -> 생성된 부스 편집하기 -> 편집내용 저장 -> 문제x
운영자모드 -> 부스 새로 생성하기 -> 상세히 생성하기 -> 내용 입력 후 부스 등록 -> 문제x
운영자모드 -> 생성된 부스 편집하기 -> 메뉴 추가하고 바로 삭제하기 -> 오류 발생
**한 플로우에서 메뉴 등록했다가 삭제 (최종등록 직전) = 문제o**

### 원인
이는 메뉴의 생성은 API 호출을 최소화하기 위해 부스의 생성/편집을 끝낼 때 이루어지는데,
반면에 메뉴 삭제는 즉각 진행하기 때문에 생기는 문제였습니다.

### 해결
최초의 메뉴 목록을 저장해두었다가 비교하여 서버에 등록이 되어있는 메뉴인지 확인하는 식으로 해결하였습니다.