### PR TITLE
Fix/bootlist card css overflow

### DIFF
--- a/src/entities/booth/ui/Item.tsx
+++ b/src/entities/booth/ui/Item.tsx
@@ -34,8 +34,8 @@ export function Item({
   return (
     <Card data-testid={`booth-item-${name}`}>
       <div className="flex items-start justify-between">
-        <div className="flex flex-col items-start justify-start min-w-0">
-          <CardHeader>
+        <div className="flex min-w-0 flex-col items-start justify-start">
+          <CardHeader className="box-border w-full">
             <CardTitle className="w-full flex-auto truncate">{name}</CardTitle>
             <CardDescription className="line-clamp-2 text-ellipsis">
               {description}

--- a/src/shared/ui/card.tsx
+++ b/src/shared/ui/card.tsx
@@ -61,7 +61,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0 box-border", className)} {...props} />
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
 ));
 CardContent.displayName = "CardContent";
 


### PR DESCRIPTION
## Summary
- 이전의 PR(#85)에서 해결한 부분이 부스 제목과 설명에는 적용되지 않았던 이슈를 해결하였습니다.
- 마찬가지로 #85 에서 실수로 다른 불필요한 css를 수정한 것을 제거하였습니다.
---
## Screenshot
<img width="1098" height="469"  alt="image" src="https://github.com/user-attachments/assets/df9a65d3-c876-4704-8f07-d6619b742252" />
<img width="1098" height="469" alt="image" src="https://github.com/user-attachments/assets/0f9375cd-5070-46fd-bd0e-eba111faa59d" />

