### PR TITLE
fix/delete-persisted-menu-item

### DIFF
--- a/src/features/menu/ui/MenuItem.tsx
+++ b/src/features/menu/ui/MenuItem.tsx
@@ -21,6 +21,7 @@ interface MenuCardProps {
   errors?: FieldErrors<Product>;
   onRemove: () => void;
   imgUrl?: string | null;
+  isDraft?: boolean;
 }
 
 export function MenuCard({
@@ -30,6 +31,7 @@ export function MenuCard({
   errors,
   onRemove,
   imgUrl,
+  isDraft,
 }: MenuCardProps) {
   const { field: imgField } = useController({
    control,

--- a/src/shared/lib/product/types.ts
+++ b/src/shared/lib/product/types.ts
@@ -3,11 +3,12 @@ import { z } from "zod";
 import { getMessage } from "../../model/zod";
 
 export const ProductSchema = z.object({
-  id: z.number(),
+  id: z.number().optional(),
   menuStatus: z.enum(["ENOUGH", "UNDER_50", "UNDER_10", "SOLD_OUT"]),
   name: z.string().min(1, getMessage("제목을 입력해주세요")).max(20, getMessage("최대 20자까지 입력 가능합니다")).trim(),
   price: z.number(),
   imgUrl: z.string().optional().nullable(),
+  isDraft: z.boolean().optional(),
 });
 
 export type Product = z.infer<typeof ProductSchema>;

--- a/src/widgets/booth/ui/Add.tsx
+++ b/src/widgets/booth/ui/Add.tsx
@@ -145,6 +145,7 @@ export function Add({ boothId }: { boothId: number }) {
   const { fields, append, remove } = useFieldArray({
     control: form.control,
     name: "menuList",
+    keyName: "fieldId",
   });
 
   return (

--- a/src/widgets/booth/ui/Edit.tsx
+++ b/src/widgets/booth/ui/Edit.tsx
@@ -129,7 +129,6 @@ export function Edit({ boothId }: { boothId: number }) {
   const { mutateAsync: createMenuItem } = useCreateMenuItem(boothId);
   const { mutateAsync: updateMenuItem } = useUpdateMenuItem();
   const { mutateAsync: patchBoothSchedule } = usePatchBoothSchedule(boothId);
-  const queryClient = useQueryClient();
 
   const { data: myProfile } = useGetMyProfile();
   const [originMenus, setOriginMenus] = useState<number[]>();


### PR DESCRIPTION
## 개요

### AS-IS
useFieldArray에서 key를 관리할 때 'id'라는 고유의 prop을 관리 => 덮어써짐


### TO-BE
useFieldArray에서 keyName prop 지정을 통해 덮어써짐을 피함.

- 부스 생성의 경우에는 메뉴가 서버에 추가될 일이 없어 부스 편집에만 해당 로직 추가