### PR TITLE
hotfix : 메뉴 제목, 부스 설명 글자수 제한 수정 / 메뉴 API 호출 순서보장

### DIFF
--- a/src/shared/lib/product/types.ts
+++ b/src/shared/lib/product/types.ts
@@ -5,7 +5,11 @@ import { getMessage } from "../../model/zod";
 export const ProductSchema = z.object({
   id: z.number().optional(),
   menuStatus: z.enum(["ENOUGH", "UNDER_50", "UNDER_10", "SOLD_OUT"]),
-  name: z.string().min(1, getMessage("제목을 입력해주세요")).max(20, getMessage("최대 20자까지 입력 가능합니다")).trim(),
+  name: z
+    .string()
+    .min(1, getMessage("제목을 입력해주세요"))
+    .max(50, getMessage("최대 50자까지 입력 가능합니다"))
+    .trim(),
   price: z.number(),
   imgUrl: z.string().optional().nullable(),
   isDraft: z.boolean().optional(),

--- a/src/widgets/booth/model/booth-edit.ts
+++ b/src/widgets/booth/model/booth-edit.ts
@@ -19,13 +19,16 @@ const scheduleSchema = z.object({
 
 export const boothEditSchema = z.object({
   category: z.nativeEnum(BoothCategory, getMessage("올바른 선택지가 아닙니다")),
-  name: z.string().min(1, getMessage("제목을 입력해주세요")).max(50, getMessage("최대 50자까지 입력 가능합니다")),
+  name: z
+    .string()
+    .min(1, getMessage("제목을 입력해주세요"))
+    .max(50, getMessage("최대 50자까지 입력 가능합니다")),
   // thumbnail: z.string().url(),
   warning: z.string().max(100, getMessage("최대 100자까지 입력 가능합니다")),
   location: z.string(),
   description: z
     .string()
-    .max(100, getMessage("최대 100자까지 입력 가능합니다")),
+    .max(500, getMessage("최대 500자까지 입력 가능합니다")),
   latitude: z.number(),
   longitude: z.number(),
   scheduleList: z.array(scheduleSchema).refine(

--- a/src/widgets/booth/ui/Edit.tsx
+++ b/src/widgets/booth/ui/Edit.tsx
@@ -150,24 +150,40 @@ export function Edit({ boothId }: { boothId: number }) {
         ...rest,
       });
 
-      // Process all menu items sequentially with Promise.all
-      await Promise.all(
-        menuList.map(async (menuItem) => {
-          const { id: menuId, isDraft: isDraft, ...menuData } = menuItem;
-          const menu = booth?.menus.find((menu) => menu.id === menuId);
+      //순서 보장 로직
+      for (const menuItem of menuList) {
+        const { id: menuId, isDraft: isDraft, ...menuData } = menuItem;
+        const menu = booth?.menus.find((menu) => menu.id === menuId);
 
-          if (menu) {
-            // Update existing menu item
-            await updateMenuItem({
-              menuId: menuId!,
-              menuData,
-            });
-          } else {
-            // Create new menu item
-            await createMenuItem(menuData);
-          }
-        }),
-      );
+        if (menu) {
+          // Update existing menu item
+          await updateMenuItem({
+            menuId: menuId!,
+            menuData,
+          });
+        } else {
+          // Create new menu item
+          await createMenuItem(menuData);
+        }
+      }
+      // Process all menu items sequentially with Promise.all
+      // await Promise.all(
+      //   menuList.map(async (menuItem) => {
+      //     const { id: menuId, isDraft: isDraft, ...menuData } = menuItem;
+      //     const menu = booth?.menus.find((menu) => menu.id === menuId);
+
+      //     if (menu) {
+      //       // Update existing menu item
+      //       await updateMenuItem({
+      //         menuId: menuId!,
+      //         menuData,
+      //       });
+      //     } else {
+      //       // Create new menu item
+      //       await createMenuItem(menuData);
+      //     }
+      //   }),
+      // );
 
       // Update schedule after all menu operations are complete
       await patchBoothSchedule({ scheduleList });
@@ -338,12 +354,12 @@ export function Edit({ boothId }: { boothId: number }) {
                     placeholder="내용을 입력해주세요"
                     {...field}
                     className="resize-none"
-                    maxLength={100}
+                    maxLength={500}
                   />
                 </FormControl>
                 <div className="mt-2 flex items-start justify-end">
                   <div className="text-[10px] font-medium text-gray">
-                    {form.getValues("description").length}/100자
+                    {form.getValues("description").length}/500자
                   </div>
                 </div>
                 <FormMessage />


### PR DESCRIPTION
## 개요
- 가천대 측 요구로 빠르게 hotfix 진행합니다.

## 메뉴 API 호출 순서 보장
### Before
<img width="296" height="341" alt="image" src="https://github.com/user-attachments/assets/0cf93d71-b65a-4f03-8015-f70e0d1925d8" />

### After
<img width="288" height="592" alt="image" src="https://github.com/user-attachments/assets/0d2ec6ea-9af8-4da4-9278-31f0e9cecaf8" />

순서가 보장되는 모습


## 글자수 제한 수정
<img width="936" height="379" alt="image" src="https://github.com/user-attachments/assets/27fae90d-968a-4b92-a7e5-cef9c3fef04b" />
<img width="945" height="627" alt="image" src="https://github.com/user-attachments/assets/abc32b6f-bdfa-4b20-8a6a-f868ea1c1123" />

제대로 500자, 100자가 반영되어있는 모습입니다.