### PR TITLE
feat: switch submit button to disabled mode while submitting or done submitting

### DIFF
--- a/src/widgets/booth/ui/Add.tsx
+++ b/src/widgets/booth/ui/Add.tsx
@@ -154,6 +154,8 @@ export function Add({ boothId }: { boothId: number }) {
     keyName: "fieldId",
   });
 
+  const { formState: { isSubmitting, isSubmitSuccessful } } = form;
+
   return (
     <>
       <EditImageBox thumbnail={thumbnail} editThumbnail={editThumbnail} />
@@ -412,6 +414,7 @@ export function Add({ boothId }: { boothId: number }) {
           >
             <Button
               className="w-full flex-[2] rounded-[10px] bg-pink py-3 text-white hover:bg-pink"
+              disabled={isSubmitting || isSubmitSuccessful}
               type="submit"
             >
               등록하기

--- a/src/widgets/booth/ui/Edit.tsx
+++ b/src/widgets/booth/ui/Edit.tsx
@@ -123,7 +123,7 @@ export function Edit({ boothId }: { boothId: number }) {
     },
   });
 
-  const { reset } = form;
+  const { reset, formState: { isSubmitting, isSubmitSuccessful } } = form;
 
   const [parent] = useAutoAnimate();
 
@@ -462,6 +462,7 @@ export function Edit({ boothId }: { boothId: number }) {
             <Button
               className="w-full flex-[2] rounded-[10px] bg-pink py-3 text-white hover:bg-pink"
               type="submit"
+              disabled={isSubmitting || isSubmitSuccessful}
             >
               등록하기
             </Button>


### PR DESCRIPTION
## 개요

### AS-IS
부스 생성과 편집 페이지에서 submit을 누르고 요청이 끝나기 전에 submit 버튼을 다시 누를 수 있었습니다.

### TO-BE
submit 요청이 진행중일 때, 그리고 submit이 성공적으로 끝났을 때 submit 버튼이 disabled되도록 설정하였습니다.

### 효과

사용자가 실수로 버튼을 여러번 눌러서 서비스가 오작동하는 것을 방지할 수 있습니다.