### PR TITLE
hotfix : 파라미터 변경으로 지도 고정되는 현상 해결

### DIFF
--- a/src/widgets/add-booth/ui/Map.tsx
+++ b/src/widgets/add-booth/ui/Map.tsx
@@ -49,7 +49,7 @@ export function GoogleMap() {
     <APIProvider apiKey={apiKey}>
       <Map
         className="h-screen w-full"
-        center={{
+        defaultCenter={{
           lat: myFestival?.latitude ?? CampusPosition.latitude,
           lng: myFestival?.longitude ?? CampusPosition.longitude,
         }}


### PR DESCRIPTION
### Summary
가천대는 부지가 넓어서 지도가 고정되면 운동장 부분에 부스를 배치할 수 없습니다
