### PR TITLE
feat: show popup for pin refresh

### DIFF
--- a/src/widgets/queue/ui/pin-container.tsx
+++ b/src/widgets/queue/ui/pin-container.tsx
@@ -17,8 +17,10 @@ export default function PINContainer({ boothId }: PINContainerPropsType) {
     useReissuePINMutation(boothId);
 
   const handleRefresh = async () => {
-    await reissuePIN();
-    regetPIN();
+    if (confirm("핀번호를 새로고침하시겠습니까?")) {
+      await reissuePIN();
+      regetPIN();
+    }
   };
 
   return (


### PR DESCRIPTION
## 개요

유저들이 실수로 핀번호 새로고침을 누르거나, 웨이팅 새로고침으로 오해하는 경우를 막기 위해서 시스템 기본 팝업을 사용했습니다.

## After

<img width="4000" height="1996" alt="image" src="https://github.com/user-attachments/assets/fffc7cba-9448-4931-8440-1519d18dbe55" />
