### PR TITLE
feat: make interval longer to avoid congestion

### DIFF
--- a/src/features/queue/api/index.ts
+++ b/src/features/queue/api/index.ts
@@ -52,7 +52,7 @@ export const useQueueGroupsQuery = (
   return useQuery({
     queryKey: queueKeys.list(boothId).queryKey,
     queryFn: () => getGroups(boothId),
-    refetchInterval: 5000,
+    refetchInterval: 60000,
   });
 };
 

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -21,7 +21,7 @@ import { match, P } from "ts-pattern";
 
 const defaultConfig: KyOptions = {
   prefixUrl: API_URL,
-  timeout: 10000,
+  timeout: false,
   retry: {
     limit: 2,
     methods: ["get", "put", "post", "delete", "patch"],
@@ -35,7 +35,7 @@ export const publicClient = ky.create({
     afterResponse: [
       async (request, options, response) => {
         if (response.status === 401) {
-          alert("아이디 또는 비밀번호를 다시 확인해주세요.")
+          alert("아이디 또는 비밀번호를 다시 확인해주세요.");
         }
       },
     ],


### PR DESCRIPTION
## 개요


- 타임아웃 10초 지날 때 에러페이지로 이동하여, 느린 네트워크 환경에서 사용자 경험 저하 => 타임아웃 없애서 개선


- 서비스의 대역폭 점유율이 낮더라도, 주기적으로 요청을 보냈을 때 지연이 비선형적으로 급격히 커질 수 있는가? (네트워크 장비들의 fairness와 연관이 있는 듯)
- 본 질문에 대해 '예'라고 가정하고, 다음과 같은 논의를 통해 변경.

1. 폴링 주기를 10초 이렇게 두면, uplink에 몰리는 타이밍이 갑자기 많아질 수 있다. 따라서, uplink에 몰리는 타이밍을 분산시킬 수 있을 거 같아서 지수 백오프가 베스트일 거 같긴 한데, 로직 자체가 복잡해서 버그 나기가 쉽다.
2. 그래서 폴링 주기를 그냥 길게해서 uplink에 덜 몰리게 하자.
3. 정성적인 웨이팅/부스 관찰에 따르면 폴링 주기는 1분이 적당할 거 같다.