### PR TITLE
fix: prevent error from being thrown by not found error

### DIFF
--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -58,8 +58,7 @@ const handleHttpError = async ({
     .with(409, () => new ConflictError(response, request, options))
     .with(400, () => new BadRequestError(response, request, options))
     .with(422, () => new ValidationError(response, request, options))
-    .with(503, () => new ServiceUnavailableError(response, request, options))
-    .otherwise(() => new ServerError(response, request, options));
+    .with(503, () => new ServiceUnavailableError(response, request, options));
 };
 
 const refreshAccessToken = async (refreshToken: string): Promise<string> => {

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -55,7 +55,6 @@ const handleHttpError = async ({
   throw match(response.status)
     .with(401, () => new UnauthorizedError(response, request, options))
     .with(403, () => new ForbiddenError(response, request, options))
-    .with(404, () => new NotFoundError(response, request, options))
     .with(409, () => new ConflictError(response, request, options))
     .with(400, () => new BadRequestError(response, request, options))
     .with(422, () => new ValidationError(response, request, options))


### PR DESCRIPTION
## 개요

- 유저가 웨이팅을 취소하고 운영자가 입장 / 호출을 하였을 때 현재 서버에서 404 응답 코드를 보냅니다.
- 일괄적으로 에러 페이지를 띄우는 대신에 alert만 띄워질 수 있도록 변경합니다.